### PR TITLE
Add first send message implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,15 @@ github {
 }
 
 dependencies {
+    testCompile "com.github.tomakehurst:wiremock-jre8:2.22.0"
+
     testCompile('org.spockframework:spock-core:1.2-groovy-2.4') {
         exclude module: 'groovy-all'
     }
+
     testCompile('com.nagternal:spock-genesis:0.6.0') {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
+
+    testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
 }

--- a/src/integrationTest/groovy/wooga/gradle/slack/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/slack/IntegrationSpec.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.slack
 
 import org.junit.Rule
 import nebula.test.functional.ExecutionResult
+import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
 
 class IntegrationSpec extends nebula.test.IntegrationSpec {
@@ -26,12 +27,21 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
     @Rule
     ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
 
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
     def setup() {
         def gradleVersion = System.getenv("GRADLE_VERSION")
         if (gradleVersion) {
             this.gradleVersion = gradleVersion
             fork = true
         }
+
+        environmentVariables.clear(
+            SlackConsts.ICON_ENV_VAR,
+            SlackConsts.USERNAME_ENV_VAR,
+            SlackConsts.WEBHOOK_ENV_VAR,
+        )
     }
 
     Boolean outputContains(ExecutionResult result, String message) {

--- a/src/integrationTest/groovy/wooga/gradle/slack/tasks/SlackIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/slack/tasks/SlackIntegrationSpec.groovy
@@ -1,0 +1,254 @@
+package wooga.gradle.slack.tasks
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import org.junit.Rule
+import spock.lang.Unroll
+import wooga.gradle.slack.IntegrationSpec
+import wooga.gradle.slack.SlackConsts
+import wooga.gradle.slack.SlackPlugin
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+
+class SlackIntegrationSpec extends IntegrationSpec {
+
+    @Rule
+    public WireMockRule wireMock = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort(), false)
+
+    def setup() {
+        //fetch webhook url from environment
+        environmentVariables.set(SlackConsts.WEBHOOK_ENV_VAR, "http://localhost:${wireMock.port()}/services")
+
+        buildFile << """
+            ${applyPlugin(SlackPlugin)}
+        """.stripIndent()
+    }
+
+    def "task :sendMessage skips when webhook, message or payload is not set"() {
+        when:
+        def result = runTasksSuccessfully("sendMessage")
+
+        then:
+        result.wasSkipped("sendMessage")
+    }
+
+    @Unroll
+    def "sends slack message with #cliSwitch and sets correct payload key #payloadKey"() {
+        given: "A stubbed ok response from the mocked server"
+        wireMock.stubFor(post(urlEqualTo("/services"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody("ok")))
+
+        when:
+        runTasksSuccessfully("sendMessage", cliSwitch, value, "--message", "test message")
+
+        then:
+        wireMock.verify(postRequestedFor(urlEqualTo("/services"))
+                .withRequestBody(containing(""" "${payloadKey}":"${value}" """.trim()))
+                .withHeader("Content-Type", equalToIgnoreCase("application/json; charset=UTF-8")))
+
+        where:
+        cliSwitch    | value                          | payloadKey
+        "--username" | "TestUser"                     | "username"
+        "--icon"     | "https://icons.com/custom.png" | "icon_url"
+        "--color"    | "#FF00FF"                      | "color"
+
+    }
+
+    @Unroll
+    def "send slack message #message"() {
+        given: "A stubbed ok response from the mocked server"
+        wireMock.stubFor(post(urlEqualTo("/services"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody("ok")))
+
+        and: "some properties in the build gradle"
+        buildFile << """
+        version = "1.0.0"
+        ext.foo = "bar"
+        ext.bar = ["baz":"faz"]
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully("sendMessage", "--message", message)
+
+        then:
+        wireMock.verify(postRequestedFor(urlEqualTo("/services"))
+                .withRequestBody(containing(expectedMessage))
+                .withHeader("Content-Type", equalToIgnoreCase("application/json; charset=UTF-8")))
+
+        where:
+        message                                                  | expectedMessage
+        "can replace gradle properties like version: #{version}" | "can replace gradle properties like version: 1.0.0"
+        "custom properties: `#{foo}`"                            | "custom properties: `bar`"
+        "deep nested object: `#{bar.baz}`"                       | "deep nested object: `faz`"
+        "deep nested with unknown key: `#{bar.x}`"               | "deep nested with unknown key: `null`"
+
+    }
+
+    def "can set #property in extension"() {
+        given: "A stubbed ok response from the mocked server"
+        wireMock.stubFor(post(urlEqualTo("/services"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody("ok")))
+
+        and: "a confgured value in the extension"
+        buildFile << """
+        slack.${property} = "${value}"
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully("sendMessage", "--message", "test message")
+
+        then:
+        wireMock.verify(postRequestedFor(urlEqualTo("/services"))
+                .withRequestBody(containing(""" "${payloadKey}":"${value}" """.trim()))
+                .withHeader("Content-Type", equalToIgnoreCase("application/json; charset=UTF-8")))
+
+        where:
+        property | value                                                                                          | payloadKey
+        "icon"   | "http://icons.iconarchive.com/icons/blackvariant/button-ui-system-apps/1024/Terminal-icon.png" | "icon_url"
+    }
+
+    @Unroll
+    def "can set webhook in #location"() {
+        given: "A stubbed ok response from the mocked server"
+        wireMock.stubFor(post(urlEqualTo("/custom/services"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody("ok")))
+
+        and: "a configured webhook in the extension"
+        buildFile << """
+        ${name}.webhook = "http://localhost:${wireMock.port()}/custom/services"
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully("sendMessage", "--message", "test message")
+
+        then:
+        wireMock.verify(postRequestedFor(urlEqualTo("/custom/services"))
+                .withRequestBody(containing(""" "text":"test message" """.trim()))
+                .withHeader("Content-Type", equalToIgnoreCase("application/json; charset=UTF-8")))
+
+        where:
+        location    | name
+        "extension" | "slack"
+        "task"      | "sendMessage"
+
+    }
+
+    def "send slack message with message payload"() {
+        given: "a custom slack message payload"
+        def payload = createFile("message_payload.json")
+        payload << """
+        {
+            "attachments": [
+                {
+                    "fallback": "ReferenceError - UI is not defined: https://honeybadger.io/path/to/event/",
+                    "text": "<https://honeybadger.io/path/to/event/|ReferenceError> - UI is not defined",
+                    "fields": [
+                        {
+                            "title": "Project",
+                            "value": "Awesome Project",
+                            "short": true
+                        },
+                        {
+                            "title": "Environment",
+                            "value": "production",
+                            "short": true
+                        }
+                    ],
+                    "color": "#F35A00"
+                }
+            ]
+        }
+        """.stripIndent()
+
+        and: "A stubbed ok response from the mocked server"
+        wireMock.stubFor(post(urlEqualTo("/services"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/html")
+                .withBody("ok")))
+
+        when:
+        runTasksSuccessfully("sendMessage", "--message-payload", "${projectDir}/message_payload.json")
+
+        then:
+        wireMock.verify(postRequestedFor(urlEqualTo("/services"))
+                .withRequestBody(equalTo(payload.text))
+                .withHeader("Content-Type", equalToIgnoreCase("application/json; charset=UTF-8")))
+
+    }
+
+    def "prints warning when send failed"() {
+        given: "A stubbed ok response from the mocked server"
+        wireMock.stubFor(post(urlEqualTo("/services"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8"))
+                .willReturn(aResponse()
+                .withStatus(404)))
+
+        when:
+        def result = runTasksSuccessfully("sendMessage", "--message", "test")
+
+        then:
+        outputContains(result, "failed to send message")
+    }
+
+    def "help prints commandline description for sendMessage"() {
+        when:
+        def result = runTasksSuccessfully("help", "--task", "sendMessage")
+
+        then:
+        result.standardOutput.contains("Path")
+        result.standardOutput.contains("Type")
+        result.standardOutput.contains("Options")
+        result.standardOutput.contains("--username")
+        result.standardOutput.contains("--color")
+        result.standardOutput.contains("--icon")
+        result.standardOutput.contains("--message")
+        result.standardOutput.contains("--message-payload")
+        result.standardOutput.contains("--webhook")
+        result.standardOutput.contains("Description")
+        result.standardOutput.contains("Group")
+    }
+
+    @Unroll
+    def "fails with `#color` #message"() {
+        expect:
+        runTasksWithFailure("sendMessage", "--color", color, "--message", message)
+
+        where:
+        color        | message
+        "#FF"        | "hex value to short"
+        "#FFFFGG"    | "invalid characters"
+        "FF0000"     | "missing hash sign"
+        "sdaksdjajd" | "random value"
+    }
+
+    @Unroll
+    def "succeeds with `#color` #message"() {
+        expect:
+        runTasksSuccessfully("sendMessage", "--color", color, "--message", message)
+
+        where:
+        color     | message
+        "#FF00FF" | "valid hex value"
+        "good"    | "valid color name"
+        "warning" | "valid color name"
+        "danger"  | "valid color name"
+    }
+}

--- a/src/main/groovy/wooga/gradle/slack/SlackConsts.groovy
+++ b/src/main/groovy/wooga/gradle/slack/SlackConsts.groovy
@@ -1,0 +1,15 @@
+package wooga.gradle.slack
+
+class SlackConsts {
+
+    static String WEBHOOK_OPTION = "slack.webhook"
+    static String WEBHOOK_ENV_VAR = "SLACK_WEBHOOK"
+
+    static String USERNAME_OPTION = "slack.username"
+    static String USERNAME_ENV_VAR = "SLACK_USERNAME"
+
+    static String ICON_OPTION = "slack.icon"
+    static String ICON_ENV_VAR = "SLACK_ICON"
+
+    static String DEFAULT_ICON = "https://raw.githubusercontent.com/alexleventer/gradle-slack-plugin/master/assets/gradlephant.png"
+}

--- a/src/main/groovy/wooga/gradle/slack/SlackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/slack/SlackPlugin.groovy
@@ -17,13 +17,70 @@
 
 package wooga.gradle.slack
 
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.logging.Logging
+import org.slf4j.Logger
+import wooga.gradle.slack.internal.DefaultSlackPluginExtension
+import wooga.gradle.slack.tasks.Slack
 
 class SlackPlugin implements Plugin<Project> {
 
+    static Logger logger = Logging.getLogger(SlackPlugin)
+
+    static String EXTENSION_NAME = "slack"
+
     @Override
     void apply(Project project) {
-        
+        def extension = create_and_configure_extension(project)
+
+        def sendMessageTask = project.tasks.create("sendMessage", Slack)
+        sendMessageTask.group = "slack"
+        sendMessageTask.description = "sends a slack message"
+
+
+        project.tasks.withType(Slack, new Action<Slack>() {
+            @Override
+            void execute(Slack slack) {
+                slack.webhook.set(extension.webhook)
+                slack.username.set(extension.username)
+                slack.icon.set(extension.icon)
+            }
+        })
+    }
+
+    protected static SlackPluginExtension create_and_configure_extension(Project project) {
+        def extension = project.extensions.create(SlackPluginExtension, EXTENSION_NAME, DefaultSlackPluginExtension, project)
+
+        extension.username.set(project.provider({
+            String username = (project.properties[SlackConsts.USERNAME_OPTION]
+                    ?: System.getenv()[SlackConsts.USERNAME_ENV_VAR]) as String
+            if (!username) {
+                username = "Gradle"
+            }
+            username
+        }))
+
+        extension.icon.set(project.provider({
+            String url = (project.properties[SlackConsts.ICON_OPTION]
+                    ?: System.getenv()[SlackConsts.ICON_ENV_VAR]) as String
+            if (!url) {
+                url = SlackConsts.DEFAULT_ICON
+            }
+
+            new URL(url)
+        }))
+
+        extension.webhook.set(project.provider({
+            String url = (project.properties[SlackConsts.WEBHOOK_OPTION]
+                    ?: System.getenv()[SlackConsts.WEBHOOK_ENV_VAR]) as String
+            if (url) {
+                return new URL(url)
+            }
+            null
+        }))
+
+        extension
     }
 }

--- a/src/main/groovy/wooga/gradle/slack/SlackPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/slack/SlackPluginExtension.groovy
@@ -1,0 +1,18 @@
+package wooga.gradle.slack
+
+import org.gradle.api.provider.Property
+
+interface SlackPluginExtension {
+
+    Property<URL> getWebhook()
+
+    void setWebhook(URL url)
+    void setWebhook(String url)
+
+    Property<String> getUsername()
+
+    Property<URL> getIcon()
+    void setIcon(URL url)
+    void setIcon(String url)
+
+}

--- a/src/main/groovy/wooga/gradle/slack/internal/DefaultSlackPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/slack/internal/DefaultSlackPluginExtension.groovy
@@ -1,0 +1,38 @@
+package wooga.gradle.slack.internal
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import wooga.gradle.slack.SlackPluginExtension
+
+class DefaultSlackPluginExtension implements SlackPluginExtension {
+
+    final Property<URL> webhook
+    final Property<String> username
+    final Property<URL> icon
+
+    @Override
+    void setWebhook(URL url) {
+        webhook.set(url)
+    }
+
+    @Override
+    void setWebhook(String url) {
+        setWebhook(new URL(url))
+    }
+
+    @Override
+    void setIcon(URL url) {
+        icon.set(url)
+    }
+
+    @Override
+    void setIcon(String url) {
+        setIcon(new URL(url))
+    }
+
+    DefaultSlackPluginExtension(Project project) {
+        this.webhook = project.objects.property(URL)
+        this.username = project.objects.property(String)
+        this.icon = project.objects.property(URL)
+    }
+}

--- a/src/main/groovy/wooga/gradle/slack/tasks/Slack.groovy
+++ b/src/main/groovy/wooga/gradle/slack/tasks/Slack.groovy
@@ -1,0 +1,177 @@
+package wooga.gradle.slack.tasks
+
+import groovy.json.JsonOutput
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.api.tasks.options.OptionValues
+
+import java.security.InvalidParameterException
+import java.util.regex.Pattern
+
+class Slack extends DefaultTask {
+
+    @Option(option = "message", description = "The message to send")
+    void setMessage(String version) {
+        message.set(version)
+    }
+
+    @Optional
+    @Input
+    final Property<String> message
+
+    @Option(option = "webhook", description = "The webhook url to send the message to")
+    void setWebhook(String url) {
+        setWebhook(new URL(url))
+    }
+
+    void setWebhook(URL url) {
+        webhook.set(url)
+    }
+
+    @Input
+    final Property<URL> webhook
+
+    @Option(option = "username", description = "The username of the sender")
+    void setUsername(String name) {
+        username.set(name)
+    }
+
+    @Optional
+    @Input
+    final Property<String> username
+
+    @Option(option = "icon", description = "The icon url for the message")
+    void setIcon(String url) {
+        setIcon(new URL(url))
+    }
+
+    void setIcon(URL url) {
+        icon.set(url)
+    }
+
+    @Optional
+    @Input
+    final Property<URL> icon
+
+    @Option(option = "color", description = "A intend color")
+    void setColor(String value) {
+        if (!validateColor(value)) {
+            throw new InvalidParameterException("The provided value for `color` is not a hex string or one of ['good', 'warning', 'danger']")
+        }
+        color.set(value)
+    }
+
+    @OptionValues('color')
+    List<String> availableColorOptions() {
+        ["hex color", "good", "warning", "danger"]
+    }
+
+    @Optional
+    @Input
+    final Property<String> color
+
+    @Option(option = "message-payload", description = "A path to a slack message payload json")
+    void setMessagePayload(String path) {
+        messagePayload.set(project.file(path))
+    }
+
+    @Optional
+    @InputFile
+    final RegularFileProperty messagePayload
+
+    Slack() {
+        message = project.objects.property(String)
+        webhook = project.objects.property(URL)
+        username = project.objects.property(String)
+        icon = project.objects.property(URL)
+        color = project.objects.property(String)
+        messagePayload = project.layout.fileProperty()
+
+        onlyIf(new Spec<Slack>() {
+            @Override
+            boolean isSatisfiedBy(Slack t) {
+                return t.webhook.present && (t.message.present || t.messagePayload.present)
+            }
+        })
+    }
+
+    @TaskAction
+    protected void send() {
+        def post = webhook.get().openConnection()
+        String json
+        if (!messagePayload.present) {
+            def message = [:]
+
+            if (username.present) {
+                message['username'] = this.username.get()
+            }
+
+            if (icon.present) {
+                message["icon_url"] = this.icon.get()
+            }
+
+            message["mrkdwn"] = true
+
+            if (color.present) {
+                def attachment = [:]
+                attachment["fallback"] = buildMessage()
+                attachment["text"] = buildMessage()
+                attachment["color"] = this.color.get()
+
+                message['attachments'] = [attachment]
+
+            } else {
+                message['text'] = buildMessage()
+            }
+
+            json = JsonOutput.toJson(message)
+        } else {
+            json = messagePayload.get().asFile.text
+        }
+
+        logger.info("Send message to slack endpoint ${webhook.get()}")
+        logger.info(json)
+
+        post.setRequestMethod("POST")
+        post.setDoOutput(true)
+        post.setRequestProperty("Content-Type", "application/json; charset=utf-8")
+        post.getOutputStream().write(json.getBytes("UTF-8"))
+        def response = post.getResponseCode()
+
+        if(response != 200) {
+            logger.warn("failed to send message")
+        }
+    }
+
+    private Boolean validateColor(String value) {
+        def colorNames = ["good", "warning", "danger"]
+        if (colorNames.contains(value)) {
+            return true
+        }
+
+        return value.matches(Pattern.compile(/^#[a-f0-9]{6}$/, Pattern.CASE_INSENSITIVE))
+    }
+
+    protected String buildMessage() {
+        def m = message.get()
+
+        m.replaceAll(/\#\{(.*?)\}/, { groups ->
+            def keyPath = groups[1] as String
+            def keys = keyPath.split(/\./)
+            def value = keys.toList().inject(project.properties) { Object container, String key ->
+                if (container != null) {
+                    return container[key]
+                }
+                null
+            }
+            value
+        })
+    }
+}

--- a/src/test/groovy/wooga/gradle/slack/SlackPluginActivationSpec.groovy
+++ b/src/test/groovy/wooga/gradle/slack/SlackPluginActivationSpec.groovy
@@ -19,7 +19,7 @@ package wooga.gradle.slack
 
 import nebula.test.PluginProjectSpec
 
-class GithubPluginActivationSpec extends PluginProjectSpec {
+class SlackPluginActivationSpec extends PluginProjectSpec {
     @Override
     String getPluginName() { 'net.wooga.slack' }
 }

--- a/src/test/groovy/wooga/gradle/slack/SlackPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/slack/SlackPluginSpec.groovy
@@ -18,8 +18,44 @@
 package wooga.gradle.slack
 
 import nebula.test.ProjectSpec
+import spock.lang.Unroll
+import wooga.gradle.slack.internal.DefaultSlackPluginExtension
+import wooga.gradle.slack.tasks.Slack
 
 class SlackPluginSpec extends ProjectSpec {
 
     public static final String PLUGIN_NAME = 'net.wooga.slack'
+
+    @Unroll("creates the task #taskName")
+    def 'Creates needed tasks'(String taskName, Class taskType) {
+        given:
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+        assert !project.tasks.findByName(taskName)
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        def task = project.tasks.findByName(taskName)
+        taskType.isInstance(task)
+
+        where:
+        taskName      | taskType
+        "sendMessage" | Slack
+    }
+
+
+    def 'Creates the [slack] extension'() {
+        given:
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+        assert !project.extensions.findByName(SlackPlugin.EXTENSION_NAME)
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        def extension = project.extensions.findByName(SlackPlugin.EXTENSION_NAME)
+        extension instanceof DefaultSlackPluginExtension
+    }
+
 }


### PR DESCRIPTION
## Description

This patch adds the first simple implementation to send a message to a slack channel via [incoming webhooks]. The plugin contains one simple task type `Slack` which contains basic properties to send a simple text message or a predefined json payload. The plugin adds a task with the name "sendMessage" of type `Slack` to the task list. This task is configurable through cli parameter and can be used as a simple shell command.

### Usage

You need a valid webhook URL to send messages to slack. There are two ways to create one.

* create a new app and enable incoming webhooks [see][getting-started]
* configure the custom integration **Incoming WebHooks**

### Commandline Interface

The help prints out all available switches `./gradlew help --task sendMessage`

```
Path
     :sendMessage

Type
     Slack (wooga.gradle.slack.tasks.Slack)

Options
     --color     A intend color
                 Available values are:
                      danger
                      good
                      hex color
                      warning

     --icon     The icon url for the message

     --message     The message to send

     --message-payload     A path to a slack message payload json

     --username     The username of the sender

     --webhook     The webhook url to send the message to

Description
     sends a slack message

Group
     slack
```

### Simple Message

To send a simple message from commandline invoke the task `sendMessage` with your message and the webhook url.

```bash
./gradlew sendMessage --message "test message" --webhook "https://hooks.slack.com/services/..."
```

![Slack](https://user-images.githubusercontent.com/2523575/55468503-cf0ae880-5603-11e9-8b48-6de4c18b2308.png)


### Message with custom icon and username

You can provide an url to a icon and the username for the message sender

```bash
./gradlew sendMessage --message "test message" --webhook "https://hooks.slack.com/services/..." --username "GradleBot" --icon "http://icons.iconarchive.com/icons/blackvariant/button-ui-system-apps/1024/Terminal-icon.png"
```

![Slack Custom Icon](https://user-images.githubusercontent.com/2523575/55468679-3163e900-5604-11e9-84ce-6994d8dcae2a.png)

### Preconfigure common properties

The task properties `webhook`, `icon` and `username` can be
configured via the `slack` extension.

**build.gradle**

```groovy
slack {
   webhook  = "https://hooks.slack.com/services/..."
   icon     = "http://icons.iconarchive.com/icons/blackvariant/button-ui-system-apps/1024/Terminal-icon.png"
   username = "GradleBot"
}
```

With these settings preconfigured you only need to provide the `--message` property

```bash
./gradlew sendMessage --message "test message"
```

> Note: The properties can also be provided via gradle properties or environment variables

### Simple message templating

The `Slack` tasks tries to replace specific template variables with gradle properties. This allows to send a message from commandline witch values configured in gradle. This feature is meant as a easy means to fetch some properties.

```bash
./gradlew sendMessage --message "Start a build for #{name} with version: #{version}"
```

![Slack Templating](https://user-images.githubusercontent.com/2523575/55468852-915a8f80-5604-11e9-97f4-9afcfabedd04.png)

### Provide some color

You can set an indent color for the message to be send. Possible values are all valid RGB hex strings and the predefined color names

* good
* warning
* danger

```bash
./gradlew sendMessage --color danger --message "Something is wrong!"
```

![Slack color](https://user-images.githubusercontent.com/2523575/55468949-c36bf180-5604-11e9-9ee7-cc5126e14e3b.png)

### Message with json payload

The slack API allows to send messages with rich content and interactive elements. For this first patch to support all these options would be an overkill. The `sendMessage` task allows to set a file path to a **message-payload**. With this you can send more advanced messages. These files could be generated by another gradle task.

**payload.json**
```
{
  "username": "Gradle",
  "icon_url": "https://raw.githubusercontent.com/alexleventer/gradle-slack-plugin/master/assets/gradlephant.png",
  "attachments": [{
    "fallback": "ReferenceError - UI is not defined: https://honeybadger.io/path/to/event/",
    "text": "<https://honeybadger.io/path/to/event/|ReferenceError> - UI is not defined",
    "fields": [{
        "title": "Project",
        "value": "Awesome Project",
        "short": true
      },
      {
        "title": "Environment",
        "value": "production",
        "short": true
      }
    ],
    "color": "#F35A00"
  }]
}
```

```bash
./gradlew sendMessage --message-payload payload.json
```

![Slack Payload](https://user-images.githubusercontent.com/2523575/55469249-64f34300-5605-11e9-8d58-abd6a4caa71d.png)

> Note: Icon and username have to be provided in the payload file.

### Create custom slack tasks

You can use the `Slack` task type to create multiple tasks that send out messages to configured slack channels.

> Note: By default all tasks of type `Slack` will fallback to the properties `webhook`, `icon` and `username` in the `slack` extension or
values in properties/environment.

**build.gradle**
```groovy

slack {
    webhook  = "https://hooks.slack.com/services/..."
    icon     = "https://st2.depositphotos.com/5266903/9617/v/950/depositphotos_96173202-stock-illustration-customer-flat-icon.jpg"
    username = "Gradle Build Bot"
}

task sendHello(type:wooga.gradle.slack.tasks.Slack) {
    username = "Greeter"
    message = "Hello World!"
}
```

```bash
./gradlew sendHello
```

![Slack custom](https://user-images.githubusercontent.com/2523575/55469670-3fb30480-5606-11e9-95fe-e069b6c9af2b.png)

The properties of the `Slack` task type are implemented with the Provider API which allows them to be lazy evaluated.

**build.gradle**
```groovy

task lazyMessage(type:wooga.gradle.slack.tasks.Slack) {
    username = "LazyDude"
    message.set(provider({"A value with a lazy variable ${project.version}".toString()}))
}
```

```bash
./gradlew lazyMessage
```

![Slack lazy](https://user-images.githubusercontent.com/2523575/55469792-86086380-5606-11e9-8232-0131fef08c76.png)

## Changes

![ADD] first send message implementation

[incoming webhooks]:		https://api.slack.com/incoming-webhooks
[getting-started]:		https://api.slack.com/incoming-webhooks#getting-started

[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
