### PR TITLE
Upgrades project to Gradle 6.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This plugin provides tasks and conventions to send slack messages.
 **build.gradle**
 ```groovy
 plugins {
-    id 'net.wooga.slack' version '0.1.0'
+    id 'net.wooga.slack' version '1.0.0'
 }
 ```
 
@@ -27,20 +27,28 @@ Documentation
 Gradle and Java Compatibility
 =============================
 
-| Gradle Version | Works       |
-| :------------- | :---------: |
-| < 4.0          | ![no]       |
-| 4.0            | ![yes]      |
-| 4.1            | ![yes]      |
-| 4.2            | ![yes]      |
-| 4.3            | ![yes]      |
-| 4.4            | ![yes]      |
-| 4.5            | ![yes]      |
-| 4.6            | ![yes]      |
-| 4.7            | ![yes]      |
-| 4.8            | ![yes]      |
-| 4.9            | ![yes]      |
-| 4.10           | ![yes]      |
+| Gradle Version  | Works  |
+| :-------------: | :----: |
+| < 5.0           | ![no]  |
+| 5.0             | ![yes] |
+| 5.1             | ![yes] |
+| 5.2             | ![yes] |
+| 5.3             | ![yes] |
+| 5.4             | ![yes] |
+| 5.5             | ![yes] |
+| 5.6             | ![yes] |
+| 5.6             | ![yes] |
+| 6.0             | ![yes] |
+| 6.1             | ![yes] |
+| 6.2             | ![yes] |
+| 6.3             | ![yes] |
+| 6.4             | ![yes] |
+| 6.5             | ![yes] |
+| 6.6             | ![yes] |
+| 6.6             | ![yes] |
+| 6.7             | ![yes] |
+| 6.8             | ![yes] |
+| 7.0             | ![yes] |
 
 Development
 ===========

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Wooga GmbH
+ * Copyright 2019-2021 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '1.4.0'
+    id 'net.wooga.plugins' version '2.0.0'
 }
 
 group 'net.wooga.gradle'
@@ -28,7 +28,7 @@ pluginBundle {
     tags = ['slack', 'messages']
 
     plugins {
-        unity {
+        slack {
             id = 'net.wooga.slack'
             displayName = 'Gradle Slack plugin'
             description = 'This plugin provides tasks and conventions to send slack messages'
@@ -41,15 +41,9 @@ github {
 }
 
 dependencies {
-    testCompile "com.github.tomakehurst:wiremock-jre8:2.22.0"
+    testImplementation "com.github.tomakehurst:wiremock-jre8:2.22.0"
 
-    testCompile('org.spockframework:spock-core:1.2-groovy-2.4') {
-        exclude module: 'groovy-all'
-    }
-
-    testCompile('com.nagternal:spock-genesis:0.6.0') {
+    testImplementation('com.nagternal:spock-genesis:0.6.0') {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
-
-    testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Wooga GmbH
+# Copyright 2019-2021 Wooga GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,4 +20,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/gradle_check_versions.sh
+++ b/gradle_check_versions.sh
@@ -1,15 +1,40 @@
 #!/usr/bin/env bash
 
-versions=("4.0" "4.1" "4.2" "4.3" "4.4" "4.5" "4.6" "4.7" "4.8" "4.9" "4.10")
+#
+# Copyright 2018-2021 Wooga GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+versions=("5.0" "5.1" "5.2" "5.3" "5.4" "5.5" "5.6.4" "6.0" "6.1" "6.2" "6.3" "6.4" "6.5" "6.6" "6.7")
+
+rm -fr build/reports
 for i in "${versions[@]}"
 do
     echo "test gradle version $i"
+    GRADLE_VERSION=$i ./gradlew test &> /dev/null
+    status=$?
+    mkdir -p "build/reports/$i"
+    mv build/reports/test "build/reports/$i"
+    if [ $status -ne 0 ]; then
+        echo "test error $i"
+    fi
+
     GRADLE_VERSION=$i ./gradlew integrationTest &> /dev/null
     status=$?
     mkdir -p "build/reports/$i"
     mv build/reports/integrationTest "build/reports/$i"
     if [ $status -ne 0 ]; then
-        echo "test error $i"
+        echo "integrationTest error $i"
     fi
 done

--- a/src/integrationTest/groovy/wooga/gradle/slack/tasks/SlackIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/slack/tasks/SlackIntegrationSpec.groovy
@@ -101,9 +101,9 @@ class SlackIntegrationSpec extends IntegrationSpec {
                 .withHeader("Content-Type", "text/html")
                 .withBody("ok")))
 
-        and: "a confgured value in the extension"
+        and: "a configured value in the extension"
         buildFile << """
-        slack.${property} = "${value}"
+        slack.${property}.set(new URL("${value}"))
         """.stripIndent()
 
         when:

--- a/src/main/groovy/wooga/gradle/slack/SlackConsts.groovy
+++ b/src/main/groovy/wooga/gradle/slack/SlackConsts.groovy
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019-2021 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package wooga.gradle.slack
 
 class SlackConsts {

--- a/src/main/groovy/wooga/gradle/slack/SlackPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/slack/SlackPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Wooga GmbH
+ * Copyright 2019-2021 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/wooga/gradle/slack/SlackPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/slack/SlackPluginExtension.groovy
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019-2021 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package wooga.gradle.slack
 
 import org.gradle.api.provider.Property

--- a/src/main/groovy/wooga/gradle/slack/internal/DefaultSlackPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/slack/internal/DefaultSlackPluginExtension.groovy
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019-2021 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package wooga.gradle.slack.internal
 
 import org.gradle.api.Project


### PR DESCRIPTION
## Description

This patch upgrades the whole plugin to be based on gradle 6.8.3. It will not be aimed to be backwards compatible with gradle older than version `5.0`.

## Changes

* ![UPDATE] ![GRADLE] to version `6.8.3`
* ![BREAK] ![GRADLE] supported backwards compatibility

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"