### PR TITLE
updated atlas plugin to 2.2.0, and added sonarqube support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!groovy
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-withCredentials([string(credentialsId: 'atlas_slack_coveralls_token', variable: 'coveralls_token')]) {
-  buildGradlePlugin plaforms: ['osx','windows','linux'], coverallsToken: coveralls_token
+withCredentials([string(credentialsId: 'atlas_slack_coveralls_token', variable: 'coveralls_token'),
+                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
+  buildGradlePlugin plaforms: ['osx','windows','linux'], coverallsToken: coveralls_token, sonarToken: sonar_token
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@
 
 withCredentials([string(credentialsId: 'atlas_slack_coveralls_token', variable: 'coveralls_token'),
                  string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
-  buildGradlePlugin plaforms: ['osx','windows','linux'], coverallsToken: coveralls_token, sonarToken: sonar_token
+  buildGradlePlugin platforms: ['osx','windows','linux'], coverallsToken: coveralls_token, sonarToken: sonar_token
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '2.0.0'
+    id 'net.wooga.plugins' version '2.2.0'
 }
 
 group 'net.wooga.gradle'


### PR DESCRIPTION
## Description
atlas plugin gradle plugin updated to 2.2.0, and added Sonarqube support on Jenkinsfile.

## Changes
* ![UPDATE] `atlas-plugin` gradle plugin to `2.2.0`
* ![NEW] Sonarqube project being uploaded on Jenkinsfile execution


[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
